### PR TITLE
Adds features: user/group deletion, public key file ussage for ssh_auth

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -67,7 +67,11 @@ user_{{ name }}_sshdir:
 user_{{ name }}_ssh_auth_{{ k.key[-20:] }}:
   ssh_auth:
     - {{ k.ensure|default('present') }}
+  {% if k.source is defined %}
+    - source: {{k.source}}
+  {% else %}
     - name: {{ k.key }}
+  {% endif %}
     - user: {{ name }}
     - enc: {{ k.enc|default('ssh-rsa') }}
 {{ set_p('comment', k)|indent(4, True) }}

--- a/users/init.sls
+++ b/users/init.sls
@@ -22,7 +22,7 @@ group_{{ name }}:
   group:
     - {{ g.ensure|default('present') }}
     - name: {{ name }}
-{% if g.ensure is not defined%}
+{% if g.ensure|default('present') == 'present' %}
 {{ set_p('gid', g)|indent(4, True) }}
 {{ set_p('system', g)|indent(4, True) }}
 {{ set_p('addusers', g)|indent(4, True) }}
@@ -39,7 +39,7 @@ user_{{ name }}:
   user:
     - {{ u.ensure|default('present') }}
     - name: {{ name }}
-{% if u.ensure is defined and u.ensure == 'absent' %}
+{% if u.ensure|default('present') == 'absent' %}
 {{ set_p('purge', u)|indent(4, True) }}
 {{ set_p('force', u)|indent(4, True) }}
 {% else %}

--- a/users/init.sls
+++ b/users/init.sls
@@ -22,11 +22,13 @@ group_{{ name }}:
   group:
     - {{ g.ensure|default('present') }}
     - name: {{ name }}
+{% if g.ensure is not defined%}
 {{ set_p('gid', g)|indent(4, True) }}
 {{ set_p('system', g)|indent(4, True) }}
 {{ set_p('addusers', g)|indent(4, True) }}
 {{ set_p('delusers', g)|indent(4, True) }}
 {{ set_p('members', g)|indent(4, True) }}
+{% endif %}
 {% endfor %}
 
 {% for id, u in users|dictsort %}

--- a/users/init.sls
+++ b/users/init.sls
@@ -20,7 +20,7 @@ extend: {{ datamap.sls_extend|default({}) }}
 
 group_{{ name }}:
   group:
-    - present
+    - {{ g.ensure|default('present') }}
     - name: {{ name }}
 {{ set_p('gid', g)|indent(4, True) }}
 {{ set_p('system', g)|indent(4, True) }}
@@ -35,8 +35,12 @@ group_{{ name }}:
 
 user_{{ name }}:
   user:
-    - present
+    - {{ u.ensure|default('present') }}
     - name: {{ name }}
+{% if u.ensure is defined and u.ensure == 'absent' %}
+{{ set_p('purge', u)|indent(4, True) }}
+{{ set_p('force', u)|indent(4, True) }}
+{% else %}
 {{ set_p('uid', u)|indent(4, True) }}
 {{ set_p('gid', u)|indent(4, True) }}
 {{ set_p('groups', u)|indent(4, True) }}
@@ -46,6 +50,8 @@ user_{{ name }}:
 {{ set_p('createhome', u)|indent(4, True) }}
 {{ set_p('password', u)|indent(4, True) }}
 {{ set_p('system', u)|indent(4, True) }}
+{{ set_p('fullname', u)|indent(4, True) }}
+
 
 user_{{ name }}_sshdir:
   file:
@@ -81,4 +87,5 @@ user_{{ name }}_ssh_config:
 {{ configsettings.content|indent(8, True) }}
     {% endfor %}
   {% endif %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
This adds:
- the ability to ensure a user or group is absent by setting the ensure parameter to "absent"
- a way to use public key files instead of specifying them inside the pillars
- the "fullname" property for users.
# Example:

```
groups:
  manage:
# absent group
    testgroup_1:
      ensure: absent
      name: testgroup_nr_one
      gid: 12463 # this and every other parameter other then name is ignored because of "ensure: absent"
    testgroup:
      name: testgroup_nr_two
      gid: 1337

users:
  manage:
# absent user
  john_doe:
    ensure: absent
    purge: true # this deletes the users home dierectories
    name: j.doe
    fullname: john.doe@example.com
  max_musterman:
    name: m.musterman
    fullname: max.musterman@example.com
    sshpubkeys:
        - key: KEY_Name
          source: salt://files/ssh_keys/m.musterman.id_rsa.pub
```
# Additional Information / Links:
- https://docs.saltstack.com/en/latest/ref/states/all/salt.states.group.html#salt.states.group.absent
- https://docs.saltstack.com/en/latest/ref/states/all/salt.states.user.html#salt.states.user.absent
- https://docs.saltstack.com/en/latest/ref/states/all/salt.states.ssh_auth.html#salt.states.ssh_auth.present
